### PR TITLE
Fix TagOptions for multiple products

### DIFF
--- a/example-product-sagemaker/main.tf
+++ b/example-product-sagemaker/main.tf
@@ -55,7 +55,7 @@ locals {
 }
 
 resource "aws_servicecatalog_tag_option_resource_association" "example_tags" {
-  for_each = toset(var.servicecatalog_tag_option_ids)
+  for_each = {for i, val in var.servicecatalog_tag_option_ids: i => val}
 
   resource_id   = aws_servicecatalog_product.example.id
   tag_option_id = each.value

--- a/example-product-sagemaker/main.tf
+++ b/example-product-sagemaker/main.tf
@@ -54,14 +54,11 @@ locals {
   class_case_product_name                        = local._product_name_convert_kebab_case_to_class_case
 }
 
-resource "aws_servicecatalog_tag_option_resource_association" "example_product_managed_by" {
-  resource_id   = aws_servicecatalog_product.example.id
-  tag_option_id = aws_servicecatalog_tag_option.product_managed_by.id
-}
+resource "aws_servicecatalog_tag_option_resource_association" "example_tags" {
+  for_each = toset(var.servicecatalog_tag_option_ids)
 
-resource "aws_servicecatalog_tag_option" "product_managed_by" {
-  key   = "ManagedBy"
-  value = "tfc"
+  resource_id   = aws_servicecatalog_product.example.id
+  tag_option_id = each.value
 }
 
 resource "aws_servicecatalog_tag_option_resource_association" "example_product_name" {

--- a/example-product-sagemaker/variables.tf
+++ b/example-product-sagemaker/variables.tf
@@ -41,3 +41,9 @@ variable "send_apply_lambda_role_arn" {
   type        = string
   description = "ARN of the IAM Role that the Send Apply Lambda Function uses to trigger applies in Terraform Cloud"
 }
+
+variable "servicecatalog_tag_option_ids" {
+  type        = list(string)
+  description = "IDs of aws_servicecatalog_tag_option associations to apply to the product"
+  default     = []
+}

--- a/example-product/main.tf
+++ b/example-product/main.tf
@@ -55,7 +55,7 @@ locals {
 }
 
 resource "aws_servicecatalog_tag_option_resource_association" "example_tags" {
-  for_each = toset(var.servicecatalog_tag_option_ids)
+  for_each = {for i, val in var.servicecatalog_tag_option_ids: i => val}
 
   resource_id   = aws_servicecatalog_product.example.id
   tag_option_id = each.value

--- a/example-product/main.tf
+++ b/example-product/main.tf
@@ -54,14 +54,11 @@ locals {
   class_case_product_name                        = local._product_name_convert_kebab_case_to_class_case
 }
 
-resource "aws_servicecatalog_tag_option_resource_association" "example_product_managed_by" {
-  resource_id   = aws_servicecatalog_product.example.id
-  tag_option_id = aws_servicecatalog_tag_option.product_managed_by.id
-}
+resource "aws_servicecatalog_tag_option_resource_association" "example_tags" {
+  for_each = toset(var.servicecatalog_tag_option_ids)
 
-resource "aws_servicecatalog_tag_option" "product_managed_by" {
-  key   = "ManagedBy"
-  value = "tfc"
+  resource_id   = aws_servicecatalog_product.example.id
+  tag_option_id = each.value
 }
 
 resource "aws_servicecatalog_tag_option_resource_association" "example_product_name" {

--- a/example-product/variables.tf
+++ b/example-product/variables.tf
@@ -41,3 +41,9 @@ variable "send_apply_lambda_role_arn" {
   type        = string
   description = "ARN of the IAM Role that the Send Apply Lambda Function uses to trigger applies in Terraform Cloud"
 }
+
+variable "servicecatalog_tag_option_ids" {
+  type        = list(string)
+  description = "IDs of aws_servicecatalog_tag_option associations to apply to the product"
+  default     = []
+}

--- a/main.tf
+++ b/main.tf
@@ -52,6 +52,11 @@ resource "aws_servicecatalog_portfolio" "portfolio" {
   provider_name = "HashiCorp Examples"
 }
 
+resource "aws_servicecatalog_tag_option" "product_managed_by" {
+  key   = "ManagedBy"
+  value = "tfc"
+}
+
 # An example product
 module "example_product" {
   source = "./example-product"
@@ -68,6 +73,7 @@ module "example_product" {
   tfc_organization = module.terraform_cloud_reference_engine.tfc_organization
   tfc_provider_arn = module.terraform_cloud_reference_engine.oidc_provider_arn
 
+  servicecatalog_tag_option_ids = [aws_servicecatalog_tag_option.product_managed_by.id]
 }
 
 module "example_product_sagemaker" {
@@ -84,4 +90,6 @@ module "example_product_sagemaker" {
   tfc_hostname     = module.terraform_cloud_reference_engine.tfc_hostname
   tfc_organization = module.terraform_cloud_reference_engine.tfc_organization
   tfc_provider_arn = module.terraform_cloud_reference_engine.oidc_provider_arn
+
+  servicecatalog_tag_option_ids = [aws_servicecatalog_tag_option.product_managed_by.id]
 }


### PR DESCRIPTION
The ManagedBy tag has a common value so needs to be defined once and associated with both products.